### PR TITLE
Don't assume that all timezones have a slash in them

### DIFF
--- a/tzlocal/darwin.py
+++ b/tzlocal/darwin.py
@@ -1,6 +1,5 @@
 from __future__ import with_statement
 import os
-import re
 import pytz
 
 _cache_tz = None
@@ -10,7 +9,8 @@ def _get_localzone():
     if not tzname or tzname not in pytz.all_timezones_set:
         # link will be something like /usr/share/zoneinfo/America/Los_Angeles.
         link = os.readlink("/etc/localtime")
-        tzname = link[link.rfind('/', 0, link.rfind('/'))+1:]
+        # strip off /usr/share/zoneinfo/
+        tzname = link[20:]
     return pytz.timezone(tzname)
 
 def get_localzone():
@@ -25,4 +25,3 @@ def reload_localzone():
     global _cache_tz
     _cache_tz = _get_localzone()
     return _cache_tz
-    


### PR DESCRIPTION
On my computer I use UTC time.

```
/etc/localtime -> /usr/share/zoneinfo/UTC
```

This errors because it ends up returning `zoneinfo/UTC` which is totally wrong.

So instead, we should just strip off the prefix path and assume everything after is correct. Since this is darwin, this should be a safer assumption.

And for reference, there are a good number of timezones listed under `/usr/share/zoneinfo` that aren't nested in a subdirectory.
