### PR TITLE
skip empty Time Zones registry key

### DIFF
--- a/tzlocal/win32.py
+++ b/tzlocal/win32.py
@@ -53,9 +53,12 @@ def get_localzone_name():
             sub = winreg.OpenKey(tzkey, subkey)
             data = valuestodict(sub)
             sub.Close()
-            if data['Std'] == tzwin:
-                tzkeyname = subkey
-                break
+            try:
+                if data['Std'] == tzwin:
+                    tzkeyname = subkey
+                    break
+            except:
+                continue
         
         tzkey.Close()
         handle.Close()


### PR DESCRIPTION
Using get_localzone() on one of my Win2003 node, I got an exception:

```python
>>> tzlocal.get_localzone()
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "...\site-packages\tzlocal\win32.py", line 82, in get_localzone
  File "...\site-packages\tzlocal\win32.py", line 56, in get_localzone_name
KeyError: 'Std'
```

By quickly scanning my registry keys, I found that some of the Time Zones keys are empty. They are:
* Argentina Standard Time
* Central Brazilian Standard Time
* Jordan Standard Time
* Mauritius Standard Time
* Morocco Standard Time
* Pakistan Standard Time
* Venezuela Standard Time

I guess the most straight forward way dealing with the problem is just skip these keys, right?