### PR TITLE
Bug fix for test failure when TZ is set.

### DIFF
--- a/tzlocal/tests.py
+++ b/tzlocal/tests.py
@@ -6,6 +6,9 @@ import pytz
 import tzlocal.unix
 
 class TzLocalTests(unittest.TestCase):
+    def setUp(self):
+        if 'TZ' in os.environ:
+            del os.environ['TZ']
 
     def test_env(self):
         tz_harare = tzlocal.unix._tz_from_env(':Africa/Harare')


### PR DESCRIPTION
The Debian reproducible builds project is rebuilding Debian packages with TZ=UTC. This causes the tzlocal test suite to fail. My fix is to remove TZ from the environment at the start of the test suite.

This is the output from the test suite before the fix.

    $ TZ=UTC python setup.py test
    test_env (tzlocal.tests.TzLocalTests) ... ok
    test_only_localtime (tzlocal.tests.TzLocalTests) ... FAIL
    test_symlink_localtime (tzlocal.tests.TzLocalTests) ... FAIL
    test_timezone (tzlocal.tests.TzLocalTests) ... FAIL
    test_timezone_setting (tzlocal.tests.TzLocalTests) ... FAIL
    test_zone_setting (tzlocal.tests.TzLocalTests) ... FAIL
    
    ======================================================================
    FAIL: test_only_localtime (tzlocal.tests.TzLocalTests)
    ----------------------------------------------------------------------
    Traceback (most recent call last):
      File "/home/edward/src/python/tzlocal/tzlocal/tests.py", line 57, in test_only_localtime
        self.assertEqual(tz.zone, 'local')
    AssertionError: 'UTC' != 'local'
    
    ======================================================================
    FAIL: test_symlink_localtime (tzlocal.tests.TzLocalTests)
    ----------------------------------------------------------------------
    Traceback (most recent call last):
      File "/home/edward/src/python/tzlocal/tzlocal/tests.py", line 52, in test_symlink_localtime
        self.assertEqual(tz.zone, 'Africa/Harare')
    AssertionError: 'UTC' != 'Africa/Harare'
    
    ======================================================================
    FAIL: test_timezone (tzlocal.tests.TzLocalTests)
    ----------------------------------------------------------------------
    Traceback (most recent call last):
      File "/home/edward/src/python/tzlocal/tzlocal/tests.py", line 34, in test_timezone
        self.assertEqual(tz.zone, 'Africa/Harare')
    AssertionError: 'UTC' != 'Africa/Harare'
    
    ======================================================================
    FAIL: test_timezone_setting (tzlocal.tests.TzLocalTests)
    ----------------------------------------------------------------------
    Traceback (most recent call last):
      File "/home/edward/src/python/tzlocal/tzlocal/tests.py", line 46, in test_timezone_setting
        self.assertEqual(tz.zone, 'Africa/Harare')
    AssertionError: 'UTC' != 'Africa/Harare'
    
    ======================================================================
    FAIL: test_zone_setting (tzlocal.tests.TzLocalTests)
    ----------------------------------------------------------------------
    Traceback (most recent call last):
      File "/home/edward/src/python/tzlocal/tzlocal/tests.py", line 40, in test_zone_setting
        self.assertEqual(tz.zone, 'Africa/Harare')
    AssertionError: 'UTC' != 'Africa/Harare'
    
    ----------------------------------------------------------------------
    Ran 6 tests in 0.001s
    
    FAILED (failures=5)
    $ 