### PR TITLE
Fix NameErrors

### DIFF
--- a/tzlocal/darwin.py
+++ b/tzlocal/darwin.py
@@ -6,7 +6,12 @@ import subprocess
 _cache_tz = None
 
 def _get_localzone():
-    pipe = Popen("systemsetup -gettimezone", shell=True, stderr=PIPE, stdout=PIPE)
+    pipe = subprocess.Popen(
+        "systemsetup -gettimezone",
+        shell=True,
+        stderr=subprocess.PIPE,
+        stdout=subprocess.PIPE
+    )
     tzname = pipe.stdout.read().replace('Time Zone: ', '').strip()
 
     if not tzname or tzname not in pytz.all_timezones_set:

--- a/tzlocal/darwin.py
+++ b/tzlocal/darwin.py
@@ -5,6 +5,7 @@ import subprocess
 
 _cache_tz = None
 
+
 def _get_localzone():
     pipe = subprocess.Popen(
         "systemsetup -gettimezone",
@@ -20,6 +21,7 @@ def _get_localzone():
         tzname = link[link.rfind("zoneinfo/") + 9:]
     return pytz.timezone(tzname)
 
+
 def get_localzone():
     """Get the computers configured local timezone, if any."""
     global _cache_tz
@@ -27,9 +29,9 @@ def get_localzone():
         _cache_tz = _get_localzone()
     return _cache_tz
 
+
 def reload_localzone():
     """Reload the cached localzone. You need to call this if the timezone has changed."""
     global _cache_tz
     _cache_tz = _get_localzone()
     return _cache_tz
-


### PR DESCRIPTION
@regebro This PR fixes the name errors arising from the change to using `subprocess.Popen` in the Darwin branch.

It also serves as confirmation that this fix works on Mac OS X 10.10.5  

