### PR TITLE
Ensure closing of subprocess on OS X

### DIFF
--- a/tzlocal/darwin.py
+++ b/tzlocal/darwin.py
@@ -7,20 +7,19 @@ _cache_tz = None
 
 
 def _get_localzone():
-    pipe = subprocess.Popen(
+    with subprocess.Popen(
         "systemsetup -gettimezone",
         shell=True,
         stderr=subprocess.PIPE,
         stdout=subprocess.PIPE
-    )
-    tzname = pipe.stdout.read().replace(b'Time Zone: ', b'').strip()
+    ) as pipe:
+        tzname = pipe.stdout.read().replace(b'Time Zone: ', b'').strip()
 
     if not tzname or tzname not in pytz.all_timezones_set:
         # link will be something like /usr/share/zoneinfo/America/Los_Angeles.
         link = os.readlink("/etc/localtime")
         tzname = link[link.rfind("zoneinfo/") + 9:]
-    pipe.stdout.close()
-    pipe.stderr.close()
+
     return pytz.timezone(tzname)
 
 


### PR DESCRIPTION
Current implementation of `tzlocal.get_localzone()` on OS X (darwin) doesn't close the subprocess it uses properly:
```
>>> import tzlocal
>>> import warnings
>>> warnings.simplefilter('default')
>>> tzlocal.get_localzone()
/usr/local/Cellar/python3/3.6.0/Frameworks/Python.framework/Versions/3.6/lib/python3.6/subprocess.py:761: ResourceWarning: subprocess 46523 is still running
  ResourceWarning, source=self)
<DstTzInfo 'Asia/Jerusalem' LMT+2:21:00 STD>
>>>
```