### PR TITLE
Fixed missing return on win32

### DIFF
--- a/tzlocal/win32.py
+++ b/tzlocal/win32.py
@@ -91,3 +91,4 @@ def reload_localzone():
     """Reload the cached localzone. You need to call this if the timezone has changed."""
     global _cache_tz
     _cache_tz = pytz.timezone(get_localzone_name())
+    return _cache_tz


### PR DESCRIPTION
On other platforms (`darwin`, `unix`), the function `reload_localzone` returns the reloaded timezone. On windows, this currently returns `None`.

The following is a simple fix! :)