### PR TITLE
Assert that system's offset equals to the timezone offset found

### DIFF
--- a/tzlocal/tests.py
+++ b/tzlocal/tests.py
@@ -7,6 +7,10 @@ import unittest
 
 from datetime import datetime
 
+from tzlocal import utils
+
+utils.assert_tz_offset = mock.MagicMock()
+
 
 class TzLocalTests(unittest.TestCase):
     def setUp(self):
@@ -42,7 +46,6 @@ class TzLocalTests(unittest.TestCase):
         os.environ['TZ'] = 'Just Nonsense'
         tz_harare = tzlocal.unix._try_tz_from_env()
         self.assertIsNone(tz_harare)
-
 
     def test_timezone(self):
         # Most versions of Ubuntu

--- a/tzlocal/unix.py
+++ b/tzlocal/unix.py
@@ -3,7 +3,6 @@ import datetime
 import os
 import re
 import pytz
-import warnings
 
 _cache_tz = None
 

--- a/tzlocal/unix.py
+++ b/tzlocal/unix.py
@@ -2,7 +2,7 @@ import os
 import pytz
 import re
 
-from . import utils
+from tzlocal import utils
 
 _cache_tz = None
 

--- a/tzlocal/unix.py
+++ b/tzlocal/unix.py
@@ -2,7 +2,6 @@ import datetime
 import os
 import pytz
 import re
-import time
 
 _cache_tz = None
 
@@ -36,7 +35,15 @@ def _try_tz_from_env():
 
 
 def _get_system_offset():
-    """Get system's timezone offset using built-in library time."""
+    """Get system's timezone offset using built-in library time.
+
+    For the Timezone constants (altzone, daylight, timezone, and tzname), the
+    value is determined by the timezone rules in effect at module load time or
+    the last time tzset() is called and may be incorrect for times in the past.
+
+    To keep compatibility with Windows, we're always importing time module here.
+    """
+    import time
     if time.daylight and time.localtime().tm_isdst > 0:
         return time.altzone
     else:

--- a/tzlocal/unix.py
+++ b/tzlocal/unix.py
@@ -1,8 +1,8 @@
-import ctypes
 import datetime
 import os
-import re
 import pytz
+import re
+import time
 
 _cache_tz = None
 
@@ -36,17 +36,11 @@ def _try_tz_from_env():
 
 
 def _get_system_offset():
-    """Get system's timezone offset using libc built-in function tzset().
-
-    The  tzset()  function  initializes  the tzname variable from the TZ
-    environment variable. In a System-V-like environment, it will also set the
-    variables timezone (seconds West of UTC).
-
-    Adapted from release 3.74 of the Linux man-pages project.
-    Also available on macOS."""
-    libc = ctypes.CDLL(None)
-    libc.tzset()
-    return ctypes.c_long.in_dll(libc, 'timezone').value * -1
+    """Get system's timezone offset using built-in library time."""
+    if time.daylight and time.localtime().tm_isdst > 0:
+        return time.altzone
+    else:
+        return time.timezone
 
 
 def _get_tz_offset(tz):

--- a/tzlocal/utils.py
+++ b/tzlocal/utils.py
@@ -1,0 +1,37 @@
+# -*- coding: utf-8 -*-
+import datetime
+
+
+def get_system_offset():
+    """Get system's timezone offset using built-in library time.
+
+    For the Timezone constants (altzone, daylight, timezone, and tzname), the
+    value is determined by the timezone rules in effect at module load time or
+    the last time tzset() is called and may be incorrect for times in the past.
+
+    To keep compatibility with Windows, we're always importing time module here.
+    """
+    import time
+    if time.daylight and time.localtime().tm_isdst > 0:
+        return time.altzone
+    else:
+        return time.timezone
+
+
+def get_tz_offset(tz):
+    """Get timezone's offset using built-in function datetime.utcoffset()."""
+    return int(datetime.datetime.now(tz).utcoffset().total_seconds())
+
+
+def assert_tz_offset(tz):
+    """Assert that system's timezone offset equals to the timezone offset found.
+
+    If they don't match, we probably have a misconfiguration, for example, an
+    incorrect timezone set in /etc/timezone file in systemd distributions."""
+    tz_offset = get_tz_offset(tz)
+    system_offset = get_system_offset()
+    msg = ('Timezone offset does not match system offset: {0} != {1}. '
+           'Please, check your config files.').format(
+        tz_offset, system_offset
+    )
+    assert tz_offset == system_offset, msg

--- a/tzlocal/win32.py
+++ b/tzlocal/win32.py
@@ -3,10 +3,13 @@ try:
 except ImportError:
     import winreg
 
-from tzlocal.windows_tz import win_tz
 import pytz
 
+from tzlocal.windows_tz import win_tz
+from tzlocal import utils
+
 _cache_tz = None
+
 
 def valuestodict(key):
     """Convert a registry key's values to a dictionary."""
@@ -16,6 +19,7 @@ def valuestodict(key):
         data = winreg.EnumValue(key, i)
         dict[data[0]] = data[1]
     return dict
+
 
 def get_localzone_name():
     # Windows is special. It has unique time zone names (in several
@@ -81,15 +85,20 @@ def get_localzone_name():
 
     return timezone
 
+
 def get_localzone():
     """Returns the zoneinfo-based tzinfo object that matches the Windows-configured timezone."""
     global _cache_tz
     if _cache_tz is None:
         _cache_tz = pytz.timezone(get_localzone_name())
+
+    utils.assert_tz_offset(_cache_tz)
     return _cache_tz
+
 
 def reload_localzone():
     """Reload the cached localzone. You need to call this if the timezone has changed."""
     global _cache_tz
     _cache_tz = pytz.timezone(get_localzone_name())
+    utils.assert_tz_offset(_cache_tz)
     return _cache_tz


### PR DESCRIPTION
If they don't match, we probably have a misconfiguration, for example, an incorrect timezone set in /etc/timezone file in systemd distributions.

We're raising an AssertionError, but it could be easily replaced with a soft warning if needed.