### PR TITLE
`tzlocal.get_localzone` fails on Termux

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -4,7 +4,7 @@ Changes
 1.5.2 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Get timezone via Termux `getprop` wrapper on Android. 
 
 
 1.5.1 (2017-12-01)

--- a/README.rst
+++ b/README.rst
@@ -25,18 +25,18 @@ These are the systems that are in theory supported:
 
  * Windows 2000 and later
 
- * Any unix-like system with a /etc/localtime or /usr/local/etc/localtime
+ * Any unix-like system with a ``/etc/localtime`` or ``/usr/local/etc/localtime``
 
 If you have one of the above systems and it does not work, it's a bug.
 Please report it.
 
-Please note that you getting a time zone called ``local``, this is not a bug, it's
+Please note that if you getting a time zone called ``local``, this is not a bug, it's
 actually the main feature of ``tzlocal``, that even if your system does NOT have a configuration file
 with the zoneinfo name of your time zone, it will still work.
 
 You can also use ``tzlocal`` to get the name of your local timezone, but only if your system is 
-configured to make that possible. ``tzlocal`` looks for the timezone name in /etc/timezone, /var/db/zoneinfo,
-/etc/sysconfig/clock and /etc/conf.d/clock. If your /etc/localtime is a symlink it can also extract the
+configured to make that possible. ``tzlocal`` looks for the timezone name in ``/etc/timezone``, ``/var/db/zoneinfo``,
+``/etc/sysconfig/clock`` and ``/etc/conf.d/clock``. If your ``/etc/localtime`` is a symlink it can also extract the
 name from that symlink.
 
 If you need the name of your local time zone, then please make sure your system is properly configured to allow that.
@@ -91,6 +91,7 @@ Contributors
 * Jakub Wilk
 * John Quarles
 * Preston Landers
+* Jean Jordaan
 
 (Sorry if I forgot someone)
 

--- a/tzlocal/unix.py
+++ b/tzlocal/unix.py
@@ -48,6 +48,12 @@ def _get_localzone(_root='/'):
     if tzenv:
         return tzenv
 
+    # Are we under Termux on Android?
+    if os.path.exists('/system/bin/getprop'):
+        import subprocess
+        androidtz = subprocess.check_output(['getprop', 'persist.sys.timezone']).strip().decode()
+        return pytz.timezone(androidtz)
+
     # Now look for distribution specific configuration files
     # that contain the timezone name.
     for configfile in ('etc/timezone', 'var/db/zoneinfo'):


### PR DESCRIPTION
https://termux.com/ offers a full Linux userland on Android without rooting.
However the Android version of Linux is a bit "special". It doesn't have `/etc/localtime`.  
Using tzlocal 1.5.1:

```
$ python
Python 2.7.14 (default, Jan  7 2018, 04:01:39)
[GCC 4.2.1 Compatible Android Clang 5.0.300080 ] on linux2
Type "help", "copyright", "credits" or "license" for more information.
>>> import tzlocal
>>> tzlocal.get_localzone()
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/data/data/com.termux/files/home/git/trellowarrior/lib/python2.7/site-packages/tzlocal/unix.py", line 131, in get_localzone
    _cache_tz = _get_localzone()
  File "/data/data/com.termux/files/home/git/trellowarrior/lib/python2.7/site-packages/tzlocal/unix.py", line 125, in _get_localzone
    raise pytz.UnknownTimeZoneError('Can not find any timezone configuration')
pytz.exceptions.UnknownTimeZoneError: 'Can not find any timezone configuration'
```

In this environment, this works to get the timezone (that's calling `/system/bin/getprop`):

```
$ getprop persist.sys.timezone
Asia/Manila
```