### PR TITLE
Fix escape characters for Python >= 3.6

### DIFF
--- a/tzlocal/unix.py
+++ b/tzlocal/unix.py
@@ -74,8 +74,8 @@ def _get_localzone(_root='/'):
     # Gentoo has a TIMEZONE setting in /etc/conf.d/clock
     # We look through these files for a timezone:
 
-    zone_re = re.compile('\s*ZONE\s*=\s*\"')
-    timezone_re = re.compile('\s*TIMEZONE\s*=\s*\"')
+    zone_re = re.compile(r'\s*ZONE\s*=\s*\"')
+    timezone_re = re.compile(r'\s*TIMEZONE\s*=\s*\"')
     end_re = re.compile('\"')
 
     for filename in ('etc/sysconfig/clock', 'etc/conf.d/clock'):


### PR DESCRIPTION
Since 3.6 Python doesn't allow invalid escape sequences. So we need to use raw strings.