### PR TITLE
Added clause to not read from /etc/timezone if the file exists but is empty

### DIFF
--- a/tzlocal/unix.py
+++ b/tzlocal/unix.py
@@ -52,7 +52,7 @@ def _get_localzone(_root='/'):
     # that contain the timezone name.
     for configfile in ('etc/timezone', 'var/db/zoneinfo'):
         tzpath = os.path.join(_root, configfile)
-        if os.path.exists(tzpath):
+        if os.path.exists(tzpath) and os.path.getsize(tzpath) > 0:
             with open(tzpath, 'rb') as tzfile:
                 data = tzfile.read()
 


### PR DESCRIPTION
When creating a port on FreeBSD, I noticed a port using tzlocal would not run because the timezone reported was ' '. Apparently on some FreeBSD systems /etc/timezone exists but is empty, so tzlocal would open the file but return an invalid time zone, causing the program to crash. I added a clause in the if statement that checked if the file is empty in addition to existing, which fixed the crash.