### PR TITLE
Fix BytesWarning: Comparison between bytes and string in unix.py

### DIFF
--- a/tzlocal/unix.py
+++ b/tzlocal/unix.py
@@ -58,7 +58,7 @@ def _get_localzone(_root='/'):
 
                 # Issue #3 was that /etc/timezone was a zoneinfo file.
                 # That's a misconfiguration, but we need to handle it gracefully:
-                if data[:5] == 'TZif2':
+                if data[:5] == b'TZif2':
                     continue
 
                 etctz = data.strip().decode()


### PR DESCRIPTION
Revealed by `python3 -bb setup.py test`:
```python
test_timezone (tzlocal.tests.TzLocalTests) ... /.../tzlocal/tzlocal/unix.py:61: BytesWarning: Comparison between bytes and string
  if data[:5] == 'TZif2':
```

Tests
-----
They all pass before and after the fix:

```shell
$ python2 -bb setup.py test                                                 
running test
Searching for pytz
Best match: pytz 2018.5
Processing pytz-2018.5-py2.7.egg

Using /home/tiger-222/projects/tzlocal/.eggs/pytz-2018.5-py2.7.egg
running egg_info
writing requirements to tzlocal.egg-info/requires.txt
writing tzlocal.egg-info/PKG-INFO
writing top-level names to tzlocal.egg-info/top_level.txt
writing dependency_links to tzlocal.egg-info/dependency_links.txt
reading manifest file 'tzlocal.egg-info/SOURCES.txt'
reading manifest template 'MANIFEST.in'
writing manifest file 'tzlocal.egg-info/SOURCES.txt'
running build_ext
test_env (tzlocal.tests.TzLocalTests) ... ok
test_fail (tzlocal.tests.TzLocalTests) ... ok
test_get_reload (tzlocal.tests.TzLocalTests) ... ok
test_only_localtime (tzlocal.tests.TzLocalTests) ... ok
test_symlink_localtime (tzlocal.tests.TzLocalTests) ... ok
test_timezone (tzlocal.tests.TzLocalTests) ... ok
test_timezone_setting (tzlocal.tests.TzLocalTests) ... ok
test_vardbzoneinfo_setting (tzlocal.tests.TzLocalTests) ... ok
test_zone_setting (tzlocal.tests.TzLocalTests) ... ok
test_win32_on_unix (tzlocal.tests.TzWin32Tests) ... ok

----------------------------------------------------------------------
Ran 10 tests in 0.011s

OK
```

```shell
$ python3 -bb setup.py test   
running test
running egg_info
writing tzlocal.egg-info/PKG-INFO
writing dependency_links to tzlocal.egg-info/dependency_links.txt
writing requirements to tzlocal.egg-info/requires.txt
writing top-level names to tzlocal.egg-info/top_level.txt
reading manifest file 'tzlocal.egg-info/SOURCES.txt'
reading manifest template 'MANIFEST.in'
writing manifest file 'tzlocal.egg-info/SOURCES.txt'
running build_ext
test_env (tzlocal.tests.TzLocalTests) ... ok
test_fail (tzlocal.tests.TzLocalTests) ... ok
test_get_reload (tzlocal.tests.TzLocalTests) ... ok
test_only_localtime (tzlocal.tests.TzLocalTests) ... ok
test_symlink_localtime (tzlocal.tests.TzLocalTests) ... ok
test_timezone (tzlocal.tests.TzLocalTests) ... ok
test_timezone_setting (tzlocal.tests.TzLocalTests) ... ok
test_vardbzoneinfo_setting (tzlocal.tests.TzLocalTests) ... ok
test_zone_setting (tzlocal.tests.TzLocalTests) ... ok
test_win32_on_unix (tzlocal.tests.TzWin32Tests) ... ok

----------------------------------------------------------------------
Ran 10 tests in 0.020s

OK
```