### PR TITLE
Fix 2 ResourceWarning: unclosed file

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,8 @@ from setuptools import setup, find_packages
 
 version = '2.0.0.dev0'
 
-long_description = open('README.rst', 'rt').read() + '\n\n' + open('CHANGES.txt', 'rt').read()
+with open('README.rst', 'rt') as readme, open('CHANGES.txt', 'rt') as changes:
+    long_description = readme.read() + '\n\n' + changes.read()
 
 
 setup(name='tzlocal',


### PR DESCRIPTION
Fixes 2 ResourceWarning:
```python
setup.py:5: ResourceWarning: unclosed file <_io.TextIOWrapper name='README.rst' mode='rt' encoding='UTF-8'>
  long_description = open('README.rst', 'rt').read() + '\n\n' + open('CHANGES.txt', 'rt').read()
setup.py:5: ResourceWarning: unclosed file <_io.TextIOWrapper name='CHANGES.txt' mode='rt' encoding='UTF-8'>
  long_description = open('README.rst', 'rt').read() + '\n\n' + open('CHANGES.txt', 'rt').read()
```