### PR TITLE
Skip comment lines in /etc/timezone

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -4,7 +4,7 @@ Changes
 2.0.0 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Skip comment lines when parsing /etc/timezone (Edward Betts)
 
 
 2.0.0b1 (2018-08-15)

--- a/tests/test_data/top_line_comment/etc/timezone
+++ b/tests/test_data/top_line_comment/etc/timezone
@@ -1,0 +1,2 @@
+# Comment on first line
+Africa/Harare

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -50,6 +50,10 @@ class TzLocalTests(unittest.TestCase):
         tz = tzlocal.unix._get_localzone(_root=os.path.join(self.path, 'test_data', 'timezone'))
         self.assertEqual(tz.zone, 'Africa/Harare')
 
+    def test_timezone_top_line_comment(self):
+        tz = tzlocal.unix._get_localzone(_root=os.path.join(self.path, 'test_data', 'top_line_comment'))
+        self.assertEqual(tz.zone, 'Africa/Harare')
+
     def test_zone_setting(self):
         # A ZONE setting in /etc/sysconfig/clock, f ex CentOS
 

--- a/tzlocal/unix.py
+++ b/tzlocal/unix.py
@@ -68,12 +68,15 @@ def _get_localzone(_root='/'):
                 if not etctz:
                     # Empty file, skip
                     continue
-                # Get rid of host definitions and comments:
-                if ' ' in etctz:
-                    etctz, dummy = etctz.split(' ', 1)
-                if '#' in etctz:
-                    etctz, dummy = etctz.split('#', 1)
-                return pytz.timezone(etctz.replace(' ', '_'))
+                for etctz in data.decode().splitlines():
+                    # Get rid of host definitions and comments:
+                    if ' ' in etctz:
+                        etctz, dummy = etctz.split(' ', 1)
+                    if '#' in etctz:
+                        etctz, dummy = etctz.split('#', 1)
+                    if not etctz:
+                        continue
+                    return pytz.timezone(etctz.replace(' ', '_'))
         except IOError:
             # File doesn't exist or is a directory
             continue


### PR DESCRIPTION
On some systems, /etc/timezone is 2 lines, a comment, then the timezone.

Reported as a bug in Ubuntu: https://bugs.launchpad.net/ubuntu/+source/python-tzlocal/+bug/1797857

This change includes a test data and a test.