### PR TITLE
Improved error handling for more than IOError

### DIFF
--- a/tzlocal/unix.py
+++ b/tzlocal/unix.py
@@ -101,6 +101,7 @@ def _get_localzone(_root='/'):
             continue
 
     # CentOS has a ZONE setting in /etc/sysconfig/clock,
+    # Centos 8 /etc/sysconfig/clock is binary and we should skip this check
     # OpenSUSE has a TIMEZONE setting in /etc/sysconfig/clock and
     # Gentoo has a TIMEZONE setting in /etc/conf.d/clock
     # We look through these files for a timezone:
@@ -134,7 +135,7 @@ def _get_localzone(_root='/'):
                         utils.assert_tz_offset(tz)
                     return tz
 
-        except IOError:
+        except Exception as e:
             # File doesn't exist or is a directory
             continue
 

--- a/tzlocal/unix.py
+++ b/tzlocal/unix.py
@@ -101,7 +101,6 @@ def _get_localzone(_root='/'):
             continue
 
     # CentOS has a ZONE setting in /etc/sysconfig/clock,
-    # Centos 8 has a binary /etc/sysconfig/clock, this will fail
     # OpenSUSE has a TIMEZONE setting in /etc/sysconfig/clock and
     # Gentoo has a TIMEZONE setting in /etc/conf.d/clock
     # We look through these files for a timezone:

--- a/tzlocal/unix.py
+++ b/tzlocal/unix.py
@@ -101,7 +101,6 @@ def _get_localzone(_root='/'):
             continue
 
     # CentOS has a ZONE setting in /etc/sysconfig/clock,
-    # Centos 8 /etc/sysconfig/clock is binary and we should skip this check
     # OpenSUSE has a TIMEZONE setting in /etc/sysconfig/clock and
     # Gentoo has a TIMEZONE setting in /etc/conf.d/clock
     # We look through these files for a timezone:
@@ -135,8 +134,8 @@ def _get_localzone(_root='/'):
                         utils.assert_tz_offset(tz)
                     return tz
 
-        except Exception as e:
-            # File doesn't exist or is a directory
+        except (IOError, UnicodeDecodeError) as e:
+            #Handle IO or Unicode Decode Errors
             continue
 
     # systemd distributions use symlinks that include the zone name,

--- a/tzlocal/unix.py
+++ b/tzlocal/unix.py
@@ -135,7 +135,7 @@ def _get_localzone(_root='/'):
                     return tz
 
         except (IOError, UnicodeDecodeError) as e:
-            #Handle IO or Unicode Decode Errors
+            #UnicodeDecode handles edge case where /etc/sysconfig/clock is symlink to /etc/localtime
             continue
 
     # systemd distributions use symlinks that include the zone name,


### PR DESCRIPTION
The code that checks /etc/sysconfig/clock errors out for Centos 8. The file appears to be binary, but the file open operation is for text.

The exception code meant to handle this only handles IOError, but not other error types. I adjusted to include
except Exception as e: -- In other words, continue on any exception not just IOError. 

This allows the code to proceed and instead inspect /etc/localtime which returns properly. 