### PR TITLE
feat: add py.typed

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,5 @@
 from setuptools import setup
 
-setup()
+setup(
+    package_data={"tzlocal": ["py.typed"]},
+)


### PR DESCRIPTION
Hi, add py.typed files for friendly hints
not add py.typed:
![111](https://user-images.githubusercontent.com/43594924/158959747-78f6f785-1d57-49f8-a4bb-a27cc277c1fb.png)
![22](https://user-images.githubusercontent.com/43594924/158959762-780f08c8-2aff-4369-88de-4a0eeffcfbcc.png)

add py.typed:
![image](https://user-images.githubusercontent.com/43594924/158959941-353c77de-5dfd-4588-8946-673a2334462b.png)
![image](https://user-images.githubusercontent.com/43594924/158959900-4de52fe8-3ad3-4aa8-952f-cfbce13a4101.png)

