### PR TITLE
Add missing string formatter to ZoneInfoNotFoundError

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -4,7 +4,7 @@ Changes
 4.3 (unreleased)
 ----------------
 
-- Nothing changed yet.
+- Improved the error message when the ZoneInfo cannot be found
 
 
 4.2 (2022-04-02)

--- a/tzlocal/utils.py
+++ b/tzlocal/utils.py
@@ -124,5 +124,5 @@ def _tz_from_env(tzenv=None):
         # Nope, it's something like "PST4DST" etc, we can't handle that.
         raise ZoneInfoNotFoundError(
             "tzlocal() does not support non-zoneinfo timezones like %s. \n"
-            "Please use a timezone in the form of Continent/City"
+            "Please use a timezone in the form of Continent/City" % tzenv
         ) from None


### PR DESCRIPTION
Previously there was a string interpolation sign (%s) but nothing was being added. This change adds tzenv to give a better error message.

### Before
```
>>> import tzlocal
>>> tzlocal.utils._tz_from_env("US/Chicago")
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/caleb/Downloads/tzlocal/tzlocal/utils.py", line 125, in _tz_from_env
    raise ZoneInfoNotFoundError(
tzlocal.utils.ZoneInfoNotFoundError: 'tzlocal() does not support non-zoneinfo timezones like %s. \nPlease use a timezone in the form of Continent/City'
```

### After
```
>>> import tzlocal
>>> tzlocal.utils._tz_from_env("US/Chicago")
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/caleb/Downloads/tzlocal/tzlocal/utils.py", line 125, in _tz_from_env
    raise ZoneInfoNotFoundError(
tzlocal.utils.ZoneInfoNotFoundError: 'tzlocal() does not support non-zoneinfo timezones like US/Chicago. \nPlease use a timezone in the form of Continent/City'
```