### PR TITLE
Fix for issue 127

### DIFF
--- a/tzlocal/unix.py
+++ b/tzlocal/unix.py
@@ -117,6 +117,8 @@ def _get_localzone_name(_root="/"):
                 pds.timezone(etctz)
                 tzinfo = f"{tzpath} is a symlink to"
                 found_configs[tzinfo] = etctz.replace(" ", "_")
+                # Only need first valid relative path in simlink. 
+                break
             except pds.UnknownTimeZoneError:
                 pass
             start = etctz.find("/") + 1


### PR DESCRIPTION
Fixes https://github.com/regebro/tzlocal/issues/127 by adding a break to the while-loop that checks for valid paths from a simlink from /etc/localtime. The behavior of the loop is to check for valid files from the top down like this: 

Example behavior with latest release and 
/etc/localtime -> /usr/share/zoneinfo/Etc/UTC

> /usr/share/zoneinfo/Etc/UTC
> usr/share/zoneinfo/Etc/UTC
> share/zoneinfo/Etc/UTC
> zoneinfo/Etc/UTC
> Etc/UTC
> UTC

Creates an invalid configuration ('Etc/UTC' and 'UTC' don't match) because both '/usr/share/zoneinfo/Etc/UTC' and '/usr/share/zoneinfo/UTC' exist and are valid configurations:

{'/etc/sysconfig/clock': 'Etc/UTC', '/etc/localtime is a symlink to': 'UTC'}

With the while loop breaking on the first valid configuration, the desired behavior is realized: 


> /usr/share/zoneinfo/Etc/UTC
> usr/share/zoneinfo/Etc/UTC
> share/zoneinfo/Etc/UTC
> zoneinfo/Etc/UTC
> Etc/UTC
{'/etc/sysconfig/clock': 'Etc/UTC', '/etc/localtime is a symlink to': 'Etc/UTC'}


Adding the break does not affect the opposite scenario, where the simlink points to /usr/share/zoneinfo/UTC, as the first valid config will still be 'UTC'. 

tests pass: 

> 
> coverage: platform linux, python 3.8.10-final-0
> Name                    Stmts   Miss  Cover
> 
> tzlocal/__init__.py         4      0   100%
> tzlocal/unix.py           116      0   100%
> tzlocal/utils.py           57      1    98%
> tzlocal/win32.py           69      1    99%
> tzlocal/windows_tz.py       3      0   100%
> 
> TOTAL                     249      2    99%