### PR TITLE
Unix: continue after getprop failed

### DIFF
--- a/tzlocal/unix.py
+++ b/tzlocal/unix.py
@@ -34,12 +34,16 @@ def _get_localzone_name(_root="/"):
     if os.path.exists(os.path.join(_root, "system/bin/getprop")):
         import subprocess
 
-        androidtz = (
-            subprocess.check_output(["getprop", "persist.sys.timezone"])
-            .strip()
-            .decode()
-        )
-        return androidtz
+        try:
+            androidtz = (
+                subprocess.check_output(["getprop", "persist.sys.timezone"])
+                .strip()
+                .decode()
+            )
+            return androidtz
+        except (OSError, subprocess.CalledProcessError):
+            # proot environment or failed to getprop
+            pass
 
     # Now look for distribution specific configuration files
     # that contain the timezone name.


### PR DESCRIPTION
Some proot scripts will map `/system` into the proot environment. Still, a proot environment is virtually an "installation" of Linux distribution and thus has no `getprop` wrapper from Termux (`/data/data/com.termux/files/usr/bin/getprop`). Even if the vanilla `getprop` (`/system/bin/getprop`) is in `PATH`, it is very likely to crash in a proot environment.

The patch is to suppress errors during trying to `getprop` in order to make `tzlocal` not crash in a proot environment.