### PR TITLE
Add support for Python 3.12 and drop EOL 3.7

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,7 +23,7 @@ jobs:
           python-version: pypy3
     runs-on: ${{ matrix.os }}
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v4
       with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12", "pypy3.8"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "pypy3.8"]
         exclude:
         - os: macos-latest
           python-version: 3.8

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "pypy3.8"]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12", "pypy3.8"]
         exclude:
         - os: macos-latest
           python-version: 3.8
@@ -28,6 +28,7 @@ jobs:
       uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
+        allow-prereleases: true
     - uses: actions/cache@v3
       with:
         path: ~/.cache/pip

--- a/README.rst
+++ b/README.rst
@@ -30,8 +30,8 @@ This Python module returns a the `IANA time zone name
 <https://www.iana.org/time-zones>`_ for your local time zone or a ``tzinfo`` 
 object with the local timezone information, under Unix and Windows.
 
-It requires Python 3.7 or later, and will use the ``backports.tzinfo``
-package, for Python 3.7 and 3.8.
+It requires Python 3.8 or later, and will use the ``backports.tzinfo``
+package, for Python 3.8.
 
 This module attempts to fix a glaring hole in the ``pytz`` and ``zoneinfo``
 modules, that there is no way to get the local timezone information, unless

--- a/setup.cfg
+++ b/setup.cfg
@@ -23,6 +23,7 @@ classifiers =
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
     Programming Language :: Python :: 3.11
+    Programming Language :: Python :: 3.12
 
 [options]
 packages = find:

--- a/setup.cfg
+++ b/setup.cfg
@@ -18,7 +18,6 @@ classifiers =
     Operating System :: MacOS :: MacOS X
     Programming Language :: Python :: 3
     Programming Language :: Python :: 3 :: Only
-    Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
@@ -27,7 +26,7 @@ classifiers =
 
 [options]
 packages = find:
-python_requires = >= 3.7
+python_requires = >= 3.8
 zip_safe = True
 install_requires =
     backports.zoneinfo; python_version < "3.9"


### PR DESCRIPTION
The [Python 3.12 release candidate](https://discuss.python.org/t/python-3-12-0-release-candidate-1-released/31137?u=hugovk) is out! :rocket:

> ## Call to action
> 
> We strongly encourage maintainers of third-party Python projects to prepare their projects for 3.12 compatibilities during this phase, and where necessary publish Python 3.12 wheels on PyPI to be ready for the final release of 3.12.0.

See also https://dev.to/hugovk/help-test-python-312-beta-1508/

---

Python 3.7 is EOL and no longer receiving security updates (or any updates) from the core Python team.

| version |  released  |    eol     |
|:--------|:----------:|:----------:|
| 3.11    | 2022-10-24 | 2027-10-24 |
| 3.10    | 2021-10-04 | 2026-10-04 |
| 3.9     | 2020-10-05 | 2025-10-05 |
| 3.8     | 2019-10-14 | 2024-10-14 |
| 3.7     | 2018-06-26 | 2023-06-27 |

https://devguide.python.org/versions/

