### PR TITLE
Downgrade debian /etc/timezone warning from warning to debug

### DIFF
--- a/tzlocal/unix.py
+++ b/tzlocal/unix.py
@@ -139,7 +139,7 @@ def _get_localzone_name(_root="/"):
         # and what's worse, they don't delete it. So we can't trust it now, 
         # so when we have multiple configs, we are forced to just ignore it.
         if len(found_configs) > 1 and "/etc/timezone" in found_configs:
-            log.warning("/etc/timezone is deprecated on Debian, and no longer reliable. Ignoring.")
+            log.debug("/etc/timezone is deprecated on Debian, and no longer reliable. Ignoring.")
             del found_configs["/etc/timezone"]
 
         # We found some explicit config of some sort!


### PR DESCRIPTION
I feel like warnings should have an actionable item for an end user.

What should the user do for the debian warning? Are you suggesting users move to something else?

https://github.com/regebro/tzlocal/blob/79da66645f8ce15c1b2d84a5cf350775c2ff81b3/tzlocal/unix.py#L142

Downgrading it a debug level would help most use cases I think.

I realize I suggested a warning in https://github.com/regebro/tzlocal/issues/165 but now that I am experiencing this, this just seems "loud".

Since this kind of stuff is boring to deal with I'm trying to make this "1 click" for you, either "merge or close" ^_^